### PR TITLE
widen analyzer version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: smoke
-version: 0.3.6+2
+version: 0.3.6+3
 author: Polymer.dart Authors <web-ui-dev@dartlang.org>
 homepage: https://github.com/dart-lang/smoke
 description: >
@@ -9,7 +9,7 @@ description: >
 dependencies:
   barback: ">=0.9.0 <0.16.0"
   logging: ">=0.9.0 <0.12.0"
-  analyzer: "^0.27.0"
+  analyzer: ">=0.27.0 <0.30.0"
 # TODO(sigmund): once we have some easier way to do global app-level
 # transformers, we might want to remove this transformer here and only apply it
 # in apps that need it.


### PR DESCRIPTION
Widen analyzer version so that smoke can be used with other packages that require analyzer 0.29.11.
See https://github.com/dart-lang/sdk/pull/29519